### PR TITLE
Configure releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+    
+      - name: Build
+        uses: ballerina-platform/ballerina-action@2201.1.1
+        with:
+          args: build
+        env:
+          WORKING_DIR: server

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -1,0 +1,62 @@
+name: 'Early Access'
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  precheck:
+    name: Precheck
+    # early-access builds only enabled in canonical repository
+    if: github.repository == 'tedneward/TicTacToeREST' && startsWith(github.event.head_commit.message, 'Releasing version') != true
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.vars.outputs.VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Version
+        id: vars
+        shell: bash
+        run: |
+          version=$(sed -n 's/version="\(.*\)"/\1/p' server/Ballerina.toml | head -n1)
+          echo ::set-output name=VERSION::$(echo "$version")
+
+  release:
+    name: Release
+    needs: [precheck]
+    # run only if version is snapshot
+    if: endsWith(${{ needs.precheck.outputs.VERSION }}, '-SNAPSHOT')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        uses: ballerina-platform/ballerina-action@2201.1.1
+        with:
+          args: build
+        env:
+          WORKING_DIR: server
+
+      - name: Release
+        uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ needs.precheck.outputs.VERSION }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jreleaser-release
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Change Version
+        run: |
+          sed -i -e 's/^version\=".*"/version="${{ github.event.inputs.version }}"/g' server/Ballerina.toml 
+          
+      - name: Build
+        uses: ballerina-platform/ballerina-action@2201.1.1
+        with:
+          args: build
+        env:
+          WORKING_DIR: server
+
+      - name: Commit Version
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Action"
+          git commit -a -m "Releasing version ${{ github.event.inputs.version }}"
+          git push origin main
+          
+      - name: Release
+        uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.version }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jreleaser-release
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ target
 hs_err_pid*
 
 **/*.mv.db
+
+# JReleaser output
+out

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,19 @@
+project:
+  name: tictactoe
+  description: REST server for a game of tic-tac-toe, also known in the UK as "naughts and crosses".
+  website: https://github.com/tedneward/TicTacToeREST
+  authors:
+    - Ted Neward
+  license: BSD-3-Clause
+  extraProperties:
+    inceptionYear: 2022
+
+release:
+  github:
+    overwrite: true
+    changelog:
+      formatted: ALWAYS
+      format: '- {{commitShortHash}} {{commitTitle}}'
+      preset: conventional-commits
+      contributors:
+        format: '- {{contributorName}}{{#contributorUsernameAsLink}} ({{.}}){{/contributorUsernameAsLink}}'


### PR DESCRIPTION
Adds release configuration via JReleaser, as well as 3 GH workflows:

- build: triggered on pull request.
- early-access: triggered on every push to `main` branch. It will create an early-access release as long as the version number (configured in `server/Ballerina.toml` ends with `-SNAPSHOT`.
- release: explicitly triggered on the UI. Must specify release version (assuming the project uses a snapshot version during development).

Releases may be posted from a local environment. You need the JReleaser CLI installed (https://jreleaser.org/guide/latest/install.html). I recommend installing via Sdkman. You also need a GitHub Personal access token (https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token may be stored as an environment variable (`JRELEASER_GITHUB_TOKEN`) or inside configuration file (https://jreleaser.org/guide/latest/configuration/environment.html). Say you choose the TOML format thus the file name and contents should look like this

**~/.jreleaser/config.toml**
```toml
JRELEASER_GITHUB_TOKEN = "value_of_gh_pat"
```

Finally, you need to tell JReleaser which version number should be used for the project. This is handled automatically in CI by reading `Ballerina.toml`. However, you must set this value manually when running on a local environment. Simply set the `JRELEASER_PROJECT_VERSION` environment variable with the desired value.

The release configuration only creates a GitHub release page at the moment, with the changelog calculated from commit messages. Additional features such as tweeting announcements, creating & publishing Docker images, additional apckage managers, may be added later to `jreleaser.yml`.